### PR TITLE
fix: remove old backups lifecycle rule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,17 +24,20 @@ resource "aws_s3_bucket_lifecycle_configuration" "state_store" {
     }
   }
 
-  rule {
-    id     = "Remove backups older than 60 days"
-    status = "Enabled"
+  dynamic "rule" {
+    for_each = var.clusters
+    content {
+      id     = "Remove ${rule.value} backups older than 60 days"
+      status = "Enabled"
 
-    filter {
-      prefix = "**/backups"
-    }
+      filter {
+        prefix = "${rule.value}/backups"
+      }
 
-    expiration {
-      days                         = 60
-      expired_object_delete_marker = false
+      expiration {
+        days                         = 60
+        expired_object_delete_marker = false
+      }
     }
   }
 }

--- a/vars.tf
+++ b/vars.tf
@@ -2,3 +2,8 @@ variable "state_store_name" {
   type        = string
   description = "Name of the bucket to be created"
 }
+
+variable "clusters" {
+  type        = list(string)
+  description = "Cluster names to use for backup removal lifecycle rule"
+}


### PR DESCRIPTION
Wildcards doesn't work in lifecycle rules.
Add clusters-variable to use for adding lifecycle rules instead.