### PR TITLE
fix: remove lifecycle rule for etcd backups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,23 +23,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "state_store" {
       noncurrent_days = 30
     }
   }
-
-  dynamic "rule" {
-    for_each = var.clusters
-    content {
-      id     = "Remove ${rule.value} backups older than 60 days"
-      status = "Enabled"
-
-      filter {
-        prefix = "${rule.value}/backups"
-      }
-
-      expiration {
-        days                         = 60
-        expired_object_delete_marker = false
-      }
-    }
-  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "state_store" {

--- a/vars.tf
+++ b/vars.tf
@@ -2,8 +2,3 @@ variable "state_store_name" {
   type        = string
   description = "Name of the bucket to be created"
 }
-
-variable "clusters" {
-  type        = list(string)
-  description = "Cluster names to use for backup removal lifecycle rule"
-}


### PR DESCRIPTION
The backups directory also contains some controls-files for etcd-manager
which should never be removed. Configure backup retention in the
cluster-spec if necessary: 'https://kops.sigs.k8s.io/cluster_spec/#etcd-backups-retention'.