### PR TITLE
fix(terraform): update required version format in providers.tf

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">=1.3.0"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Correct the formatting of the required_version in providers.tf to ensure
consistency and compatibility with versioning conventions. This change
removes the unnecessary decimal zero in the version string.