### PR TITLE
fix: add filter to S3 bucket lifecycle rule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "state_store" {
     id     = "Remove versions older than 30 days"
     status = "Enabled"
 
+    filter {}
+
     noncurrent_version_expiration {
       noncurrent_days = 30
     }


### PR DESCRIPTION
Adds an empty filter block to the S3 bucket lifecycle rule. 
This removes the deprecation warning from the AWS provider.