### PR TITLE
fix: add blocked_encryption_types to S3 encryption config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,9 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "state_store" {
   bucket = aws_s3_bucket.state_store.id
 
   rule {
+    blocked_encryption_types = ["NONE"]
+    bucket_key_enabled       = false
+
     apply_server_side_encryption_by_default {
       kms_master_key_id = var.kms_key
       sse_algorithm     = "aws:kms"


### PR DESCRIPTION
Adds explicit blocked_encryption_types = ["NONE"] and bucket_key_enabled = false to prevent recurring plan drift caused by AWS returning these attributes from the API.